### PR TITLE
Added interval routines support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented in this file.
 ### Added
 - Added `shell.spawn()` `symbol` parameter support for the command `string/array`. If an `array` is used to allow command parameters, each of the `array` members also supports `symbols` and `string templates`.
 - Added `json.stringify()` support for a `space` parameter, allowing a nicely formatted output.
+- Added interval routines support accessible through the `routines` object. Additionally this routine includes a mechanism that will cause the it to stop if it detects too many subsequent errors
 
 ### Fixed
 - Fixed `forIn()` handler issue that caused the loop that stopped the loop from ever iterating over any object key when a `symbol` was used for reading event object data.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,3 +12,6 @@ export const CONFIGURATION_FILENAMES = [ DEFAULT_CONFIGURATION_FILENAME ]
 // VERSIONS
 export const RELEASE_VERSION_STRING = (JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json'), 'utf-8')) as Record<string, string>).version
 export const RELEASE_VERSION = RELEASE_VERSION_STRING.split('.').map(x => Number(x)) as [number, number, number]
+
+// SAFEGUARDS
+export const MAX_FAILED_RETRY_COUNT = 5

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -31,6 +31,11 @@ export interface Routines {
             rateLimiter?: number
         }
     }>
+    /** Interval routines configuration. */
+    interval?: Array<{
+        time: number
+        handle: EventHandler
+    }>
 }
 
 export const ZRoutines = z.object({
@@ -39,6 +44,10 @@ export const ZRoutines = z.object({
         file: string(),
         handle: z.function(),
         options: z.any().optional()
+    })).optional(),
+    interval: array(z.object({
+        time: number(),
+        handle: z.function()
     })).optional()
 })
 


### PR DESCRIPTION
- Added `interval` routines support in the Soybean configuration (`routines.interval[]`). 
```ts
export default Soybean({
    routines: {
        interval: [
            {
                time: 100,
                handle: handlers.handle(e => { throw "woops..." })
            }
        ]
    }
})
```
This routine has an additional mechanism that stops it if an error is thrown from within the handler `n` times and warns the user of the issue:
```
WARN Infinite error loop detected - Routine #0 disabled.
```