### PR TITLE
Added dot/bracket notation alternative to `e.get`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project are documented in this file.
 - Added `shell.spawn()` `symbol` parameter support for the command `string/array`. If an `array` is used to allow command parameters, each of the `array` members also supports `symbols` and `string templates`.
 - Added `json.stringify()` support for a `space` parameter, allowing a nicely formatted output.
 - Added interval routines support accessible through the `routines` object. Additionally this routine includes a mechanism that will cause the it to stop if it detects too many subsequent errors
+- Event object data can now be read using normal dot/bracket donation. Setting properties this way is not possible due to conflicts with object properties assigned dynamically inside certain event handlers.
+    ```ts
+    e.set('arr1', ['my', 'array'])
+    console.log(e.arr1)
+    ```
 
 ### Fixed
 - Fixed `forIn()` handler issue that caused the loop that stopped the loop from ever iterating over any object key when a `symbol` was used for reading event object data.

--- a/README.md
+++ b/README.md
@@ -232,6 +232,11 @@ The different types of events include:
         ```ts
         event.set(key: string, data: any)
         ```
+        Alternatively, it is possible to read properties directly (Only available as read-only. It isn't possible to **set** data this way).
+        ```ts
+        event.key = 'string'
+        event["key"] = 'string'
+        ```
     - `SoybeanEvent.get()` - Used to retrieve a piece of data set on the event object with `set()`.
         ```ts
         event.get(key: string)

--- a/src/lib/events/events.ts
+++ b/src/lib/events/events.ts
@@ -7,7 +7,21 @@ export type EventType = 'event' | 'terminal' | 'launch' | 'watcher'
 
 // Events ===========================================================
 
+export interface SoybeanEvent {
+    [key: string]: any
+}
 export class SoybeanEvent {
+
+    constructor() {
+        // Issue: https://github.com/4S1ght/Soybean/issues/11
+        // Using a proxy to enable dot/bracket notation instead of e.set() and e.get() for cleaner syntax
+        // Only allows getters as setters produce too many conflicts with handler-scoped event properties.
+        return new Proxy<SoybeanEvent>(this, {
+            get: (target, prop: string) => {
+                return target[prop] || target.get(prop)
+            }
+        })
+    }
 
     /** The event source specifies from where the event had originated from. */
     public source: EventType = 'event'


### PR DESCRIPTION
- Added dot/bracket notation alternative to `e.get` using a `Proxy` with combination with the base `SoybeanEvent` class.
```ts
// Set the data
event.set('data', 'some data...')
// Read using e.get:
event.get('data')
// Read with dot notation:
const data = event.data
// Read with bracket notaion:
const data = event['data']
```