### PR TITLE
Added child process routines & handlers symbol support

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ Soybean({
 | `stdout` | `"all" \| "none"` | Specifies whether or not to pipe the child process' `STDOUT`, this will effectively mute the child process if used with `"none"` or display all of it's output if used with `"all"`. |
 | `cwd` | `string` | The current working directory of the child process, relative to the Soybean configuration file. |
 | `deferNext` | `number` | Time in `ms` for which to wait with further execution after spawning this process. This allows for tricks like spawning a compiler and waiting a second before spawning a different process that relies on the compiler's output. |
+| `onSpawn` | `EventHandler` | An event handler called whenever the process is spawned. |
+| `onKill` | `EventHandler` | An event handler called whenever the process is killed by the user, so either through the terminal using the `kl` command or by another `cp.kill` event handler. |
+| `onClose` | `EventHandler` | An event handler called whenever the process quits on its own. |
 
 The child process' configuration object accepts the above properties, as well as standard options available for [`child_process.spawn()`](https://nodejs.org/api/child_process.html#child_processspawncommand-args-options) such as `shell` or `signal`, with exception of `stdio` and `detached` which were either disabled or altered due to how soybean operates.
 
@@ -257,6 +260,11 @@ The different types of events include:
 - `TerminalEvent` - Event emitted when a user-specified command is entered in the integrated terminal.
     - `WatchEven.argv` (`string[]`) - An array of space-separated command parameters passed after the command keyword.
     - `WatchEven.argvRaw` (`string`) - The raw string of text passed after the command keyword.
+        - All of which are available through `event.get()`.
+
+- `ChildProcessEvent` - Event emitted by a child process when it's killed, revived, restarted or dies unexpectedly, configurable through [child process options](#child-process-configuration-options).
+    - `ChildProcessEvent.processName` (`string`) - The name of the process that triggered the event.
+    - `ChildProcessEvent.exitCode` (`number | null`) - The exit code returned by the child process, if the event originated from the process' death.
         - All of which are available through `event.get()`.
 
 ## Using symbols
@@ -660,21 +668,21 @@ Use them for managing the lifecycle of your child processes, like restarting a c
 Kills a child process of a given name if it's alive.  
 **Note**: Use the `pcs` command in the integrated terminal to check the process' status.
 ```ts
-cp.kill(process: string)
+cp.kill(process: string | symbol)
 ```
 
 ### `cp.revive()`
 Revives a dead child process of a given name if it's dead.  
 **Note**: Use the `pcs` command in the integrated terminal to check the process' status.
 ```ts
-cp.kill(process: string)
+cp.revive(process: string | symbol)
 ```
 
 ### `cp.restart()`
 Restarts a child process of a given name.  
 Unlike `cp.kill` and `cp.revive`, `cp.restart` works no matter if the child process is alive or dead. If it's dead, it will simply be revived, if it's alive, it will be killed and brought back.
 ```ts
-cp.kill(process: string)
+cp.restart(process: string | symbol)
 ```
 
 ## Shell handlers

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,4 +14,7 @@ export const RELEASE_VERSION_STRING = (JSON.parse(fs.readFileSync(path.join(__di
 export const RELEASE_VERSION = RELEASE_VERSION_STRING.split('.').map(x => Number(x)) as [number, number, number]
 
 // SAFEGUARDS
-export const MAX_FAILED_RETRY_COUNT = 5
+export const BREAKER_INTERVAL_ERROR_MAX_COUNT = 5
+
+export const BREAKER_PROCESS_RESTART_MAX_COUNT = 3
+export const BREAKER_PROCESS_RESTART_COOLDOWN = 10 * 1000

--- a/src/lib/events/events.ts
+++ b/src/lib/events/events.ts
@@ -161,17 +161,17 @@ export class WatchEvent extends SoybeanEvent {
 export class ChildProcessEvent extends SoybeanEvent {
 
     public source: EventType = 'child_process'
-    public name: string
+    public processName: string
     public exitCode: number | null
 
     constructor(name: string, ref: CP.ChildProcess) {
 
         super()
 
-        this.name = name
+        this.processName = name
         this.exitCode = ref.exitCode
 
-        this.set('name', name)
+        this.set('processName', name)
         this.set('exitCode', ref.exitCode)
 
     }

--- a/src/lib/events/events.ts
+++ b/src/lib/events/events.ts
@@ -1,9 +1,10 @@
 
 import type FS from 'fs'
+import type CP from 'child_process'
 import type { WatchEventType } from 'fs'
 
 /** Event types used across the map */
-export type EventType = 'event' | 'terminal' | 'launch' | 'watcher'
+export type EventType = 'event' | 'terminal' | 'launch' | 'watcher' | 'child_process'
 
 // Events ===========================================================
 
@@ -155,6 +156,26 @@ export class WatchEvent extends SoybeanEvent {
         this.set('watchEventType', this.watchEventType)
 
     }
+}
+
+export class ChildProcessEvent extends SoybeanEvent {
+
+    public source: EventType = 'child_process'
+    public name: string
+    public exitCode: number | null
+
+    constructor(name: string, ref: CP.ChildProcess) {
+
+        super()
+
+        this.name = name
+        this.exitCode = ref.exitCode
+
+        this.set('name', name)
+        this.set('exitCode', ref.exitCode)
+
+    }
+
 }
 
 // Handlers =========================================================

--- a/src/lib/events/handlers/cp.ts
+++ b/src/lib/events/handlers/cp.ts
@@ -19,11 +19,12 @@ const pmi = () => ProcessManager.getLiveInstance()
  * Kills the child process of a given name.  
  * Acts similar to the `kl` command.
  */
-export function kill<Event extends E.SoybeanEvent = E.SoybeanEvent>(process: string): E.EventHandler<Event> {
+export function kill<Event extends E.SoybeanEvent = E.SoybeanEvent>(name: string | Symbol): E.EventHandler<Event> {
     return (e) => new Promise<null | Error>(async end => {
         try {
-            helpers.getLoggerType(e.source)(`kill "${process}"`)
+            const process = helpers.getStoredValue(e, name)
             const cp = pmi().children.get(process)
+            helpers.getLoggerType(e.source)(`kill "${process}"`)
 
             if (!cp) throw new Error(`Could not find process "${process}"`)
             await cp.kill()
@@ -37,13 +38,14 @@ export function kill<Event extends E.SoybeanEvent = E.SoybeanEvent>(process: str
 
 /**
  * Restarts the child process of a given name.  
- * Acts similar to the `kl` command.
+ * Acts similar to the `rs` command.
  */
-export function restart<Event extends E.SoybeanEvent = E.SoybeanEvent>(process: string): E.EventHandler<Event> {
+export function restart<Event extends E.SoybeanEvent = E.SoybeanEvent>(name: string | Symbol): E.EventHandler<Event> {
     return (e) => new Promise<null | Error>(async end => {
         try {
-            helpers.getLoggerType(e.source)(`restart "${process}"`)
+            const process = helpers.getStoredValue(e, name)
             const cp = pmi().children.get(process)
+            helpers.getLoggerType(e.source)(`restart "${process}"`)
 
             if (!cp) throw new Error(`Could not find process "${process}"`)
             await cp.restart()
@@ -57,13 +59,14 @@ export function restart<Event extends E.SoybeanEvent = E.SoybeanEvent>(process: 
 
 /**
  * Revives the child process of a given name.  
- * Acts similar to the `kl` command.
+ * Acts similar to the `rv` command.
  */
-export function revive<Event extends E.SoybeanEvent = E.SoybeanEvent>(process: string): E.EventHandler<Event> {
+export function revive<Event extends E.SoybeanEvent = E.SoybeanEvent>(name: string | Symbol): E.EventHandler<Event> {
     return (e) => new Promise<null | Error>(async end => {
         try {
-            helpers.getLoggerType(e.source)(`revive "${process}"`)
+            const process = helpers.getStoredValue(e, name)
             const cp = pmi().children.get(process)
+            helpers.getLoggerType(e.source)(`revive "${process}"`)
 
             if (!cp) throw new Error(`Could not find process "${process}"`)
             await cp.revive()

--- a/src/lib/process/child_process.ts
+++ b/src/lib/process/child_process.ts
@@ -52,7 +52,7 @@ export default class ChildProcess extends EventProxy<ProcessEvent> {
             self.spawnTime = Date.now()
             self.emitSafe('spawn')
             // Resume "close" because it might have been paused by kill()
-            self.resume('spawn')
+            self.resume('close')
         })
 
         this.ref.on('exit', () => {

--- a/src/lib/program.ts
+++ b/src/lib/program.ts
@@ -15,6 +15,7 @@ import { SoybeanEvent, LaunchEvent, TerminalEvent, WatchEvent, ChildProcessEvent
 import commands from "./terminal/liveterminal_commands.js"
 
 import * as url from 'url'
+import { kMaxLength } from 'buffer'
 const __filename = url.fileURLToPath(import.meta.url)
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 
@@ -32,13 +33,19 @@ const createRateLimiter = (time: number) => {
     return executor
 }
 
-const createBreaker = (cooldown: number, onBreak: Function) => {
+interface BreakerConfig {
+    cooldown: number
+    threshold: number
+    onBreak: Function
+    onTrigger: Function
+}
+const createBreaker = ({ cooldown, threshold, onBreak, onTrigger}: BreakerConfig) => {
     let runCount = 0
-    function trigger(callback: Function) {
+    function trigger() {
         runCount++
-        if (runCount > constants.MAX_FAILED_RETRY_COUNT) onBreak()
-        else callback()
-        setTimeout(() => runCount = 0, cooldown * constants.MAX_FAILED_RETRY_COUNT + cooldown * 0.9)
+        if (runCount > kMaxLength) onBreak()
+        else onTrigger()
+        setTimeout(() => runCount = 0, cooldown * threshold + cooldown * 0.9)
     }
     return trigger
 }
@@ -123,9 +130,18 @@ export default class Program {
         for (let i = 0; i < this.config.routines.interval.length; i++) {
 
             const { time, handle } = this.config.routines.interval[i]
-            const trigger = createBreaker(time, () => {
-                clearInterval(interval)
-                Terminal.WARN(`Infinite error loop detected - Routine #${i} disabled.`)
+            let errorMessage: Error
+
+            const trigger = createBreaker({
+                cooldown: time,
+                threshold: constants.BREAKER_INTERVAL_ERROR_MAX_COUNT,
+                onTrigger: () => {
+                    Terminal.ERROR(`An error was encountered while performing operation:`, errorMessage)
+                },
+                onBreak: () => {
+                    clearInterval(interval)
+                    Terminal.WARN(`Infinite error loop detected - Routine #${i} disabled.`)
+                }
             })
 
             const interval = setInterval(async() => {
@@ -134,7 +150,8 @@ export default class Program {
                 const error = await handle(event)
     
                 if (error) {
-                    trigger(() => Terminal.ERROR(`An error was encountered while performing operation:`, error))
+                    errorMessage = error
+                    trigger()
                 }
 
             }, time)
@@ -159,21 +176,52 @@ export default class Program {
             process.on('spawn',         ()    =>        Terminal.INFO(`Process "${name}" is running.`))
 
             // Child process lifecycle routines
+            const cooldown = constants.BREAKER_PROCESS_RESTART_COOLDOWN
+            const threshold = constants.BREAKER_PROCESS_RESTART_MAX_COUNT
 
-            if (this.config.cp[name].onClose)
-            process.on('close', () => { 
-                this.config.cp![name].onClose!(new ChildProcessEvent(name, this.processManager.children.get(name)!.ref)) 
-            })
+            if (this.config.cp[name].onClose) {
+                const trigger = createBreaker({
+                    cooldown,
+                    threshold,
+                    onTrigger: () => {
+                        this.config.cp![name].onClose!(new ChildProcessEvent(name, this.processManager.children.get(name)!.ref))
+                    },
+                    onBreak: () => {
+                        Terminal.WARN(`The "onClose" event handler for process "${name}" has been blocked as it seems to be causing in an infinite loop.`)
+                        process.removeListener('close', trigger)
+                    }
+                })
+                process.on('close', trigger)
+            }
 
-            if (this.config.cp[name].onKill)
-            process.on('kill', () => { 
-                this.config.cp![name].onKill!(new ChildProcessEvent(name, this.processManager.children.get(name)!.ref)) 
-            })
+            if (this.config.cp[name].onKill) {
+                const trigger = createBreaker({
+                    cooldown,
+                    threshold,
+                    onTrigger: () => {
+                        this.config.cp![name].onKill!(new ChildProcessEvent(name, this.processManager.children.get(name)!.ref))
+                    },
+                    onBreak: () => {
+                        Terminal.WARN(`The "onKill" event handler for process "${name}" has been blocked as it seems to be causing in an infinite loop.`)
+                        process.removeListener('kill', trigger)
+                    }
+                })
+                process.on('close', trigger)
+            }
 
-            if (this.config.cp[name].onSpawn)
-            process.on('spawn', () => { 
-                this.config.cp![name].onSpawn!(new ChildProcessEvent(name, this.processManager.children.get(name)!.ref)) 
-            })
+            if (this.config.cp[name].onSpawn) {
+                const trigger = createBreaker({
+                    cooldown,
+                    threshold,
+                    onTrigger: () => {
+                        this.config.cp![name].onSpawn!(new ChildProcessEvent(name, this.processManager.children.get(name)!.ref))
+                    },
+                    onBreak: () => {
+                        Terminal.WARN(`The "onSpawn" event handler for process "${name}" has been blocked as it seems to be causing an infinite loop.`)
+                        process.removeListener('spawn', trigger)
+                    }
+                })
+            }
 
         }
 

--- a/src/lib/program.ts
+++ b/src/lib/program.ts
@@ -39,11 +39,11 @@ interface BreakerConfig {
     onBreak: Function
     onTrigger: Function
 }
-const createBreaker = ({ cooldown, threshold, onBreak, onTrigger}: BreakerConfig) => {
+const createBreaker = ({ cooldown, threshold, onBreak, onTrigger }: BreakerConfig) => {
     let runCount = 0
     function trigger() {
         runCount++
-        if (runCount > kMaxLength) onBreak()
+        if (runCount > threshold) onBreak()
         else onTrigger()
         setTimeout(() => runCount = 0, cooldown * threshold + cooldown * 0.9)
     }
@@ -206,7 +206,7 @@ export default class Program {
                         process.removeListener('kill', trigger)
                     }
                 })
-                process.on('close', trigger)
+                process.on('kill', trigger)
             }
 
             if (this.config.cp[name].onSpawn) {
@@ -221,6 +221,7 @@ export default class Program {
                         process.removeListener('spawn', trigger)
                     }
                 })
+                process.on('spawn', trigger)
             }
 
         }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,7 +1,7 @@
 
 import z, { union, literal, string, number, boolean, array, record, object } from 'zod'
 import type cp from 'child_process'
-import type { EventHandler, TerminalEvent, LaunchEvent } from './events/events.js'
+import type { EventHandler, TerminalEvent, LaunchEvent, ChildProcessEvent } from './events/events.js'
 import type FS from 'fs'
 
 // ==================================================================
@@ -76,6 +76,20 @@ export interface SpawnOptions extends Omit<cp.SpawnOptions, 'stdio' | 'detached'
      * process after the current one had started (in milliseconds)
      */
     deferNext?: number
+    /** 
+     * Called whenever the process exits unexpectedly - Without user interaction
+     * like the use of aa `restart` handler or `rs` terminal command. 
+     */
+    onClose?: EventHandler<ChildProcessEvent>
+    /** 
+     * Called whenever the process is forcefully killed by the user 
+     * using a `restart/kill` handler or using the terminal.
+     */
+    onKill?: EventHandler<ChildProcessEvent>
+    /** 
+     * Called whenever the process is spawned - Including when it's restarted or revived.
+     */
+    onSpawn?: EventHandler<ChildProcessEvent>
 
 }
 
@@ -84,6 +98,9 @@ export const ZSpawnOptions = z.object({
     cwd: string().optional(),
     stdout: union([ literal('all'), z.literal('none') ]).optional(),
     deferNext: number().optional(),
+    onClose: z.function().optional(),
+    onKill: z.function().optional(),
+    onSpawn: z.function().optional(),
     // Illegal
     stdio: z.undefined(),
     detached: z.undefined()


### PR DESCRIPTION
Child processes now accept `onSpawn`, `onKill` and `onClose` event handlers that react to their lifecycle events.
In addition `cp.kill`, `cp.restart` & `cp.revive` handlers now support symbol parameters which allow for code that reads the process' data from the event object more easily.

Example:
```js
cp: {
  node: {
    command: 'node',
      onClose: handlers.group([
        handlers.handle(e => console.log(`Exit code: ${e.exitCode}`)),
        handlers.cp.restart('{{processName}}')
    ])
  }
}
```